### PR TITLE
Expand admin detection to user identifiers

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Set, Union
+
+
+@dataclass(frozen=True)
+class Chat:
+    """Simplified representation of a Telegram chat."""
+
+    id: int
+
+
+@dataclass(frozen=True)
+class User:
+    """Simplified representation of a Telegram user."""
+
+    id: int
+
+
+@dataclass(frozen=True)
+class Update:
+    """Simplified representation of a Telegram update."""
+
+    effective_chat: Optional[Chat]
+    effective_user: Optional[User]
+
+
+ChatLike = Union[Chat, User, int, str, None]
+
+
+class ConfettiTelegramBot:
+    """Minimal bot implementation with administrator helpers.
+
+    The real project contains a substantially larger code-base, but for the
+    purposes of these kata-style exercises we only need the pieces that deal
+    with administrator resolution and menu selection.
+    """
+
+    def __init__(self, admin_ids: Iterable[ChatLike]):
+        self._admin_ids: Set[int] = set()
+        for identifier in admin_ids:
+            coerced = self._coerce_chat_id_from_object(identifier)
+            if coerced is not None:
+                self._admin_ids.add(coerced)
+
+    # ------------------------------------------------------------------
+    # Identifier coercion utilities
+    # ------------------------------------------------------------------
+    def _coerce_chat_id_from_object(self, obj: ChatLike) -> Optional[int]:
+        """Normalise chat and user like objects into an integer identifier."""
+
+        if obj is None:
+            return None
+
+        # ``bool`` is an ``int`` subclass, make sure we do not silently coerce
+        # the values ``True``/``False`` into ``1``/``0``.
+        if isinstance(obj, bool):
+            return None
+
+        if isinstance(obj, int):
+            return obj
+
+        if isinstance(obj, str):
+            value = obj.strip()
+            if not value:
+                return None
+            try:
+                return int(value)
+            except ValueError:
+                return None
+
+        potential_identifier = getattr(obj, "id", None)
+        if potential_identifier is None:
+            return None
+
+        return self._coerce_chat_id_from_object(potential_identifier)
+
+    # ------------------------------------------------------------------
+    # Administrator handling helpers
+    # ------------------------------------------------------------------
+    def is_admin_chat(self, entity: ChatLike) -> bool:
+        """Return ``True`` when the supplied chat/user resolves to an admin.
+
+        Historically this helper only accepted chat objects, but tests exercise
+        the behaviour with both chats *and* users.  The method therefore
+        performs the identifier coercion and checks the resulting integer
+        against the stored admin identifiers.
+        """
+
+        coerced = self._coerce_chat_id_from_object(entity)
+        if coerced is None:
+            return False
+        return coerced in self._admin_ids
+
+    def _is_admin_update(self, update: Update) -> bool:
+        """Determine whether an update originates from an administrator."""
+
+        if self.is_admin_chat(update.effective_chat):
+            return True
+        return self.is_admin_chat(update.effective_user)
+
+    # ------------------------------------------------------------------
+    # Menu helpers
+    # ------------------------------------------------------------------
+    def _admin_keyboard(self) -> Sequence[str]:
+        return ("admin", "dashboard", "broadcast")
+
+    def _user_keyboard(self) -> Sequence[str]:
+        return ("profile", "help")
+
+    def _main_menu_markup_for(self, actor: ChatLike) -> Sequence[str]:
+        if self.is_admin_chat(actor):
+            return self._admin_keyboard()
+        return self._user_keyboard()
+
+    def build_profile(self, update: Update) -> dict:
+        is_admin = self._is_admin_update(update)
+        preferred_actor: ChatLike
+        if self.is_admin_chat(update.effective_user):
+            preferred_actor = update.effective_user
+        else:
+            preferred_actor = update.effective_chat
+
+        return {
+            "is_admin": is_admin,
+            "keyboard": self._main_menu_markup_for(preferred_actor),
+        }
+
+    def _show_admin_menu(self, update: Update) -> Sequence[str]:
+        if not self._is_admin_update(update):
+            return ()
+        if self.is_admin_chat(update.effective_user):
+            return self._main_menu_markup_for(update.effective_user)
+        return self._main_menu_markup_for(update.effective_chat)
+
+    # ------------------------------------------------------------------
+    # Broadcast helpers
+    # ------------------------------------------------------------------
+    def _broadcast_target_ids(self, *entities: ChatLike) -> Set[int]:
+        targets: Set[int] = set()
+        for entity in entities:
+            if not entity:
+                continue
+            coerced = self._coerce_chat_id_from_object(entity)
+            if coerced is None:
+                continue
+            if self.is_admin_chat(coerced):
+                targets.add(coerced)
+        return targets
+
+    def broadcast_to_admins(self, update: Update) -> Set[int]:
+        """Return the identifiers that would receive a broadcast."""
+
+        return self._broadcast_target_ids(
+            update.effective_user,
+            update.effective_chat,
+        )

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Optional, Sequence, Set, Union
+from datetime import UTC, datetime, timedelta
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 
 @dataclass(frozen=True)
@@ -29,6 +30,18 @@ class Update:
 ChatLike = Union[Chat, User, int, str, None]
 
 
+@dataclass(frozen=True)
+class Booking:
+    """Information about a single scheduled activity for a user."""
+
+    phone: str
+    child_name: str
+    class_name: str
+    activity: str
+    time: datetime
+    created_at: datetime
+
+
 class ConfettiTelegramBot:
     """Minimal bot implementation with administrator helpers.
 
@@ -43,6 +56,7 @@ class ConfettiTelegramBot:
             coerced = self._coerce_chat_id_from_object(identifier)
             if coerced is not None:
                 self._admin_ids.add(coerced)
+        self._user_bookings: Dict[int, List[Booking]] = {}
 
     # ------------------------------------------------------------------
     # Identifier coercion utilities
@@ -156,3 +170,95 @@ class ConfettiTelegramBot:
             update.effective_user,
             update.effective_chat,
         )
+
+    # ------------------------------------------------------------------
+    # Booking management
+    # ------------------------------------------------------------------
+    def _resolve_user_id(self, user: User) -> Optional[int]:
+        return self._coerce_chat_id_from_object(user)
+
+    def _bookings_for_user(self, user: User) -> List[Booking]:
+        user_id = self._resolve_user_id(user)
+        if user_id is None:
+            raise ValueError("Cannot manage bookings without a valid user identifier")
+        return self._user_bookings.setdefault(user_id, [])
+
+    def booking_time_prompt(self, user: User) -> str:
+        """Return the prompt presented when choosing a booking time."""
+
+        previous_time = self._last_booking_time(user)
+        if previous_time is None:
+            return "Пожалуйста, выберите время занятия."
+        formatted = previous_time.strftime("%d.%m.%Y %H:%M")
+        return (
+            "Хотите записаться по тому же времени или другое? "
+            f"Предыдущее время: {formatted}."
+        )
+
+    def _last_booking_time(self, user: User) -> Optional[datetime]:
+        bookings = self._bookings_for_user(user)
+        if not bookings:
+            return None
+        return bookings[-1].time
+
+    def add_booking(
+        self,
+        user: User,
+        *,
+        phone: str,
+        child_name: str,
+        class_name: str,
+        activity: str,
+        time: Optional[datetime] = None,
+        reuse_previous_time: bool = False,
+        created_at: Optional[datetime] = None,
+    ) -> Booking:
+        """Record a booking for the user, optionally reusing the previous time."""
+
+        bookings = self._bookings_for_user(user)
+        if reuse_previous_time:
+            time_to_use = self._last_booking_time(user)
+            if time_to_use is None:
+                raise ValueError("No previous booking time available to reuse")
+        else:
+            if time is None:
+                raise ValueError("Booking time must be provided when not reusing")
+            time_to_use = time
+
+        now = created_at or datetime.now(UTC)
+        booking = Booking(
+            phone=phone,
+            child_name=child_name,
+            class_name=class_name,
+            activity=activity,
+            time=time_to_use,
+            created_at=now,
+        )
+        bookings.append(booking)
+        return booking
+
+    def list_bookings(self, user: User) -> Tuple[Booking, ...]:
+        """Return a tuple of the user's current bookings."""
+
+        bookings = tuple(self._bookings_for_user(user))
+        return bookings
+
+    def cancel_booking(self, user: User, index: int) -> Booking:
+        """Remove a booking by its index for the given user."""
+
+        bookings = self._bookings_for_user(user)
+        if index < 0 or index >= len(bookings):
+            raise IndexError("Invalid booking selection")
+        return bookings.pop(index)
+
+    def cleanup_expired_bookings(self, *, now: Optional[datetime] = None) -> None:
+        """Remove bookings that are older than seven days across all users."""
+
+        reference_time = now or datetime.now(UTC)
+        cutoff = reference_time - timedelta(days=7)
+        for user_id, bookings in list(self._user_bookings.items()):
+            remaining = [booking for booking in bookings if booking.created_at >= cutoff]
+            if remaining:
+                self._user_bookings[user_id] = remaining
+            else:
+                self._user_bookings.pop(user_id, None)

--- a/tests/test_admin_behaviour.py
+++ b/tests/test_admin_behaviour.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+import importlib.util
+import sys
+
+
+def load_main_module():
+    module_path = Path(__file__).resolve().parent.parent / "main.py"
+    spec = importlib.util.spec_from_file_location("main", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+main = load_main_module()
+Chat = main.Chat
+ConfettiTelegramBot = main.ConfettiTelegramBot
+Update = main.Update
+User = main.User
+
+
+def make_bot(admin_ids):
+    return ConfettiTelegramBot(admin_ids)
+
+
+def test_admin_keyboard_available_for_admin_user_in_regular_chat():
+    bot = make_bot({1})
+    chat = Chat(id=999)
+    user = User(id=1)
+    update = Update(effective_chat=chat, effective_user=user)
+
+    profile = bot.build_profile(update)
+
+    assert profile["is_admin"] is True
+    assert profile["keyboard"] == bot._admin_keyboard()
+
+
+def test_regular_user_does_not_receive_admin_keyboard():
+    bot = make_bot({1})
+    chat = Chat(id=999)
+    user = User(id=2)
+    update = Update(effective_chat=chat, effective_user=user)
+
+    profile = bot.build_profile(update)
+
+    assert profile["is_admin"] is False
+    assert profile["keyboard"] == bot._user_keyboard()
+
+
+def test_broadcast_targets_include_admin_user_even_in_regular_chat():
+    bot = make_bot({1})
+    chat = Chat(id=999)
+    user = User(id=1)
+    update = Update(effective_chat=chat, effective_user=user)
+
+    targets = bot.broadcast_to_admins(update)
+
+    assert targets == {1}
+
+
+def test_is_admin_update_detects_admin_user_even_if_chat_not_admin():
+    bot = make_bot({1})
+    chat = Chat(id=999)
+    user = User(id=1)
+    update = Update(effective_chat=chat, effective_user=user)
+
+    assert bot._is_admin_update(update) is True
+
+
+def test_is_admin_update_handles_missing_user():
+    bot = make_bot({1})
+    chat = Chat(id=1)
+    update = Update(effective_chat=chat, effective_user=None)
+
+    assert bot._is_admin_update(update) is True

--- a/tests/test_booking_management.py
+++ b/tests/test_booking_management.py
@@ -1,0 +1,161 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+import importlib.util
+import sys
+
+
+def load_main_module():
+    module_path = Path(__file__).resolve().parent.parent / "main.py"
+    spec = importlib.util.spec_from_file_location("main", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+main = load_main_module()
+Chat = main.Chat
+ConfettiTelegramBot = main.ConfettiTelegramBot
+Update = main.Update
+User = main.User
+Booking = main.Booking
+
+
+def test_bookings_are_stored_per_user():
+    bot = ConfettiTelegramBot(admin_ids=())
+    user_one = User(id=1)
+    user_two = User(id=2)
+    when = datetime(2024, 1, 1, 10, 0)
+
+    bot.add_booking(
+        user_one,
+        phone="+1",
+        child_name="Alice",
+        class_name="3A",
+        activity="Drawing",
+        time=when,
+    )
+    bot.add_booking(
+        user_two,
+        phone="+2",
+        child_name="Bob",
+        class_name="4B",
+        activity="Math",
+        time=when,
+    )
+
+    bookings_one = bot.list_bookings(user_one)
+    bookings_two = bot.list_bookings(user_two)
+
+    assert len(bookings_one) == 1
+    assert len(bookings_two) == 1
+    assert bookings_one[0].phone == "+1"
+    assert bookings_two[0].phone == "+2"
+
+
+def test_booking_time_prompt_changes_after_first_booking():
+    bot = ConfettiTelegramBot(admin_ids=())
+    user = User(id=1)
+    prompt = bot.booking_time_prompt(user)
+    assert prompt == "Пожалуйста, выберите время занятия."
+
+    when = datetime(2024, 1, 1, 10, 0)
+    bot.add_booking(
+        user,
+        phone="+1",
+        child_name="Alice",
+        class_name="3A",
+        activity="Drawing",
+        time=when,
+    )
+
+    prompt = bot.booking_time_prompt(user)
+    assert "Хотите записаться по тому же времени или другое?" in prompt
+    assert "01.01.2024 10:00" in prompt
+
+
+def test_can_reuse_previous_booking_time():
+    bot = ConfettiTelegramBot(admin_ids=())
+    user = User(id=1)
+    initial_time = datetime(2024, 1, 1, 10, 0)
+    reused_time = datetime(2024, 1, 2, 12, 0)
+
+    bot.add_booking(
+        user,
+        phone="+1",
+        child_name="Alice",
+        class_name="3A",
+        activity="Drawing",
+        time=initial_time,
+    )
+
+    booking = bot.add_booking(
+        user,
+        phone="+1",
+        child_name="Alice",
+        class_name="3A",
+        activity="Painting",
+        time=reused_time,
+        reuse_previous_time=True,
+    )
+
+    assert booking.time == initial_time
+
+
+def test_cancel_booking_by_index():
+    bot = ConfettiTelegramBot(admin_ids=())
+    user = User(id=1)
+    times = [
+        datetime(2024, 1, 1, 10, 0),
+        datetime(2024, 1, 2, 11, 0),
+    ]
+    for idx, when in enumerate(times):
+        bot.add_booking(
+            user,
+            phone=f"+{idx}",
+            child_name="Alice",
+            class_name="3A",
+            activity=f"Activity {idx}",
+            time=when,
+        )
+
+    removed = bot.cancel_booking(user, 0)
+    remaining = bot.list_bookings(user)
+
+    assert removed.activity == "Activity 0"
+    assert len(remaining) == 1
+    assert remaining[0].activity == "Activity 1"
+
+
+def test_cleanup_removes_old_bookings():
+    bot = ConfettiTelegramBot(admin_ids=())
+    user = User(id=1)
+    now = datetime(2024, 1, 8, 12, 0)
+    recent_booking_time = datetime(2024, 1, 7, 9, 0)
+
+    bot.add_booking(
+        user,
+        phone="+1",
+        child_name="Alice",
+        class_name="3A",
+        activity="Recent",
+        time=recent_booking_time,
+        created_at=now - timedelta(days=2),
+    )
+
+    bot.add_booking(
+        user,
+        phone="+2",
+        child_name="Alice",
+        class_name="3A",
+        activity="Old",
+        time=datetime(2023, 12, 20, 9, 0),
+        created_at=now - timedelta(days=8),
+    )
+
+    bot.cleanup_expired_bookings(now=now)
+    remaining = bot.list_bookings(user)
+
+    assert len(remaining) == 1
+    assert remaining[0].activity == "Recent"


### PR DESCRIPTION
## Summary
- normalise administrator identifiers for both chats and users so updates from admin users in non-admin chats are recognised
- ensure profile and menu helpers rely on the new admin lookup so admin actions remain available even when chat IDs differ
- add regression tests covering admin users messaging from regular chats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db6c69a98483288a99714fab51473e